### PR TITLE
Fixed issue regarding type fields with a directive without a resolver 🐛

### DIFF
--- a/example/schema/index.ts
+++ b/example/schema/index.ts
@@ -9,7 +9,7 @@ export default gql`
 
   type Post {
     name: String!
-    published: Boolean!
+    published: Boolean! @hasRole(roles: ["ADMIN"])
   }
 
   input CreatePostInput {

--- a/src/directives/hasPermission.ts
+++ b/src/directives/hasPermission.ts
@@ -1,4 +1,4 @@
-import { GraphQLField, GraphQLInputField, GraphQLInputObjectType } from "graphql";
+import { GraphQLField, GraphQLInputField, GraphQLInputObjectType, defaultFieldResolver } from "graphql";
 import { SchemaDirectiveVisitor } from "graphql-tools";
 
 import { hasPermissionHandler } from "../defaultHandlers";
@@ -8,13 +8,13 @@ export default (overiddeHandler: ((ctx: any, permissions: string[]) => void) | u
 
   return class HasPermissionDirective extends SchemaDirectiveVisitor {
     public visitFieldDefinition(field: GraphQLField<any, any>): void {
-      const { resolve } = field;
+      const { resolve = defaultFieldResolver } = field;
       const { permissions } = this.args;
 
       field.resolve = async function(...args) {
         const ctx = args[2];
         handler(ctx, permissions);
-        return resolve!.apply(this, args);
+        return resolve.apply(this, args);
       };
     }
 

--- a/src/directives/hasRole.ts
+++ b/src/directives/hasRole.ts
@@ -1,4 +1,4 @@
-import { GraphQLField, GraphQLInputField, GraphQLInputObjectType } from "graphql";
+import { GraphQLField, GraphQLInputField, GraphQLInputObjectType, defaultFieldResolver } from "graphql";
 import { SchemaDirectiveVisitor } from "graphql-tools";
 
 import { hasRoleHandler } from "../defaultHandlers";
@@ -8,13 +8,13 @@ export default (overiddeHandler: ((ctx: any, roles: string[]) => void) | undefin
 
   return class HasRoleDirective extends SchemaDirectiveVisitor {
     public visitFieldDefinition(field: GraphQLField<any, any>): void {
-      const { resolve } = field;
+      const { resolve = defaultFieldResolver } = field;
       const { roles } = this.args;
 
       field.resolve = async function(...args) {
         const ctx = args[2];
         handler(ctx, roles);
-        return resolve!.apply(this, args);
+        return resolve.apply(this, args);
       };
     }
 

--- a/src/directives/isAuthenticated.ts
+++ b/src/directives/isAuthenticated.ts
@@ -1,4 +1,4 @@
-import { GraphQLField, GraphQLInputField, GraphQLInputObjectType } from "graphql";
+import { GraphQLField, GraphQLInputField, GraphQLInputObjectType, defaultFieldResolver } from "graphql";
 import { SchemaDirectiveVisitor } from "graphql-tools";
 
 import { isAuthenticatedHandler } from "../defaultHandlers";
@@ -8,12 +8,12 @@ export default (overiddeHandler: ((ctx: any) => void) | undefined) => {
 
   return class IsAuthenticatedDirective extends SchemaDirectiveVisitor {
     public visitFieldDefinition(field: GraphQLField<any, any>): void {
-      const { resolve } = field;
+      const { resolve = defaultFieldResolver } = field;
 
       field.resolve = async function(...args) {
         const ctx = args[2];
         handler(ctx);
-        return resolve!.apply(this, args);
+        return resolve.apply(this, args);
       };
     }
 

--- a/tests/__snapshots__/hasPermission.test.ts.snap
+++ b/tests/__snapshots__/hasPermission.test.ts.snap
@@ -24,6 +24,34 @@ Object {
 }
 `;
 
+exports[`Testing hasPermission directive without handler overriding should allow accessing a type's field with a resolver with the necessary permissions 1`] = `
+Object {
+  "unprotectedQuery": Object {
+    "protectedFieldWithResolver": "protectedFieldWithResolver",
+  },
+}
+`;
+
+exports[`Testing hasPermission directive without handler overriding should allow accessing a type's field with a resolver without the necessary permissions 1`] = `
+Array [
+  [GraphQLError: Insufficient permissions. Missing one of these: PROTECTED_FIELD],
+]
+`;
+
+exports[`Testing hasPermission directive without handler overriding should allow accessing a type's field without a resolver with the necessary permissions 1`] = `
+Object {
+  "unprotectedQuery": Object {
+    "protectedFieldWithoutResolver": "protectedFieldWithoutResolver",
+  },
+}
+`;
+
+exports[`Testing hasPermission directive without handler overriding should allow accessing a type's field without a resolver without the necessary permissions 1`] = `
+Array [
+  [GraphQLError: Insufficient permissions. Missing one of these: PROTECTED_FIELD],
+]
+`;
+
 exports[`Testing hasPermission directive without handler overriding should allow accessing another mutation's input that is not protected 1`] = `
 Object {
   "protectedMutation": "@MUTATION Input: foo Protected Input: undefined",

--- a/tests/__snapshots__/hasRole.test.ts.snap
+++ b/tests/__snapshots__/hasRole.test.ts.snap
@@ -30,6 +30,34 @@ Object {
 }
 `;
 
+exports[`Testing hasRole directive without handler overriding should allow accessing a type's field with a resolver with the necessary roles 1`] = `
+Object {
+  "unprotectedQuery": Object {
+    "protectedFieldWithResolver": "protectedFieldWithResolver",
+  },
+}
+`;
+
+exports[`Testing hasRole directive without handler overriding should allow accessing a type's field with a resolver without the necessary roles 1`] = `
+Array [
+  [GraphQLError: Insufficient roles. Missing one of these: ADMIN],
+]
+`;
+
+exports[`Testing hasRole directive without handler overriding should allow accessing a type's field without a resolver with the necessary roles 1`] = `
+Object {
+  "unprotectedQuery": Object {
+    "protectedFieldWithoutResolver": "protectedFieldWithoutResolver",
+  },
+}
+`;
+
+exports[`Testing hasRole directive without handler overriding should allow accessing a type's field without a resolver without the necessary roles 1`] = `
+Array [
+  [GraphQLError: Insufficient roles. Missing one of these: ADMIN],
+]
+`;
+
 exports[`Testing hasRole directive without handler overriding should prevent accessing a mutation without the necessary roles 1`] = `
 Array [
   [GraphQLError: Insufficient roles. Missing one of these: ADMIN, SUPER_ADMIN],

--- a/tests/__snapshots__/isAuthenticated.test.ts.snap
+++ b/tests/__snapshots__/isAuthenticated.test.ts.snap
@@ -23,3 +23,19 @@ Object {
   "protectedQuery": "@QUERY Input: foo Protected Input: undefined",
 }
 `;
+
+exports[`Testing isAuthenticated directive without handler overriding should allow accessing a type's field with a resolver authenticated 1`] = `
+Object {
+  "unprotectedQuery": Object {
+    "protectedFieldWithResolver": "protectedFieldWithResolver",
+  },
+}
+`;
+
+exports[`Testing isAuthenticated directive without handler overriding should allow accessing a type's field without a resolver authenticated 1`] = `
+Object {
+  "unprotectedQuery": Object {
+    "protectedFieldWithoutResolver": "protectedFieldWithoutResolver",
+  },
+}
+`;

--- a/tests/isAuthenticated.test.ts
+++ b/tests/isAuthenticated.test.ts
@@ -18,8 +18,14 @@ describe("Testing isAuthenticated directive without handler overriding", () => {
             input: String!
             protectedInput: String @isAuthenticated
           }
+          type TestResponse {
+            field: String!
+            protectedFieldWithoutResolver: String @isAuthenticated
+            protectedFieldWithResolver: String @isAuthenticated
+          }
           type Query {
             protectedQuery(data: TestInput!): String!
+            unprotectedQuery: TestResponse!
           }
           type Mutation {
             protectedMutation(data: TestInput!): String! @isAuthenticated
@@ -83,6 +89,34 @@ describe("Testing isAuthenticated directive without handler overriding", () => {
           protectedInput: "bar",
         },
       },
+    });
+
+    expect(res.data).toMatchSnapshot();
+  });
+
+  it("should allow accessing a type's field without a resolver authenticated", async () => {
+    const res = await client.query({
+      query: gql`
+        {
+          unprotectedQuery {
+            protectedFieldWithoutResolver
+          }
+        }
+      `,
+    });
+
+    expect(res.data).toMatchSnapshot();
+  });
+
+  it("should allow accessing a type's field with a resolver authenticated", async () => {
+    const res = await client.query({
+      query: gql`
+        {
+          unprotectedQuery {
+            protectedFieldWithResolver
+          }
+        }
+      `,
     });
 
     expect(res.data).toMatchSnapshot();

--- a/tests/utils/createClient.ts
+++ b/tests/utils/createClient.ts
@@ -13,6 +13,13 @@ export const createClient = (
       Query: {
         protectedQuery: (parent, args) =>
           `@QUERY Input: ${args.data.input} Protected Input: ${args.data.protectedInput}`,
+        unprotectedQuery: () => ({
+          field: "field",
+          protectedFieldWithoutResolver: "protectedFieldWithoutResolver",
+        }),
+      },
+      TestResponse: {
+        protectedFieldWithResolver: () => "protectedFieldWithResolver",
       },
       Mutation: {
         protectedMutation: (parent, args) =>


### PR DESCRIPTION
It errors out if a directive was used on a type's field and it doesn't have a resolver defined.
Defaults to `defaultFieldResolver`.